### PR TITLE
Target for cloudwatch datasources.

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -339,7 +339,7 @@ class CloudWatchTarget(object):
     hide = attr.ib(default=False, validator=instance_of(bool))
 
     def to_json_data(self):
-        d = {
+        return {
             'region': self.region,
             'namespace': self.namespace,
             'metricName': self.metricName,
@@ -354,8 +354,6 @@ class CloudWatchTarget(object):
             'datasource': self.datasource,
             'hide': self.hide,
         }
-        print(d)
-        return d
 
 
 @attr.s

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -322,6 +322,41 @@ class Target(object):
 
 
 @attr.s
+class CloudWatchTarget(object):
+    region = attr.ib(default="")
+    namespace = attr.ib(default="")
+    metricName = attr.ib(default="")
+    statistics = attr.ib(default=attr.Factory(list)),
+    dimensions = attr.ib(default=attr.Factory(dict)),
+    id = attr.ib(default="")
+    expression = attr.ib(default="")
+    period = attr.ib(default="")
+    alias = attr.ib(default="")
+    highResolution = attr.ib(default=False, validator=instance_of(bool))
+
+    refId = attr.ib(default="")
+    datasource = attr.ib(default="")
+    hide = attr.ib(default=False)
+
+    def to_json_data(self):
+        return {
+            'region': self.region,
+            'namespace': self.namespace,
+            'metricName': self.metricName,
+            'statistics': self.statistics,
+            'dimensions': self.dimensions,
+            'id': self.id,
+            'expression': self.expression,
+            'period': self.period,
+            'alias': self.alias,
+            'highResolution': self.highResolution,
+            'refId': self.refId,
+            'datasource': self.datasource,
+            'hide': self.hide,
+        }
+
+
+@attr.s
 class Tooltip(object):
 
     msResolution = attr.ib(default=True, validator=instance_of(bool))

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -336,10 +336,10 @@ class CloudWatchTarget(object):
 
     refId = attr.ib(default="")
     datasource = attr.ib(default="")
-    hide = attr.ib(default=False)
+    hide = attr.ib(default=False, validator=instance_of(bool))
 
     def to_json_data(self):
-        return {
+        d = {
             'region': self.region,
             'namespace': self.namespace,
             'metricName': self.metricName,
@@ -354,6 +354,8 @@ class CloudWatchTarget(object):
             'datasource': self.datasource,
             'hide': self.hide,
         }
+        print(d)
+        return d
 
 
 @attr.s

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -326,8 +326,8 @@ class CloudWatchTarget(object):
     region = attr.ib(default="")
     namespace = attr.ib(default="")
     metricName = attr.ib(default="")
-    statistics = attr.ib(default=attr.Factory(list)),
-    dimensions = attr.ib(default=attr.Factory(dict)),
+    statistics = attr.ib(default=attr.Factory(list))
+    dimensions = attr.ib(default=attr.Factory(dict))
     id = attr.ib(default="")
     expression = attr.ib(default="")
     period = attr.ib(default="")

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -1,5 +1,7 @@
 """Tests for core."""
 
+import pytest
+
 import grafanalib.core as G
 
 
@@ -33,3 +35,59 @@ def test_single_stat():
     assert data['targets'] == targets
     assert data['datasource'] == data_source
     assert data['title'] == title
+
+
+CW_TESTDATA = [
+    pytest.param(
+        {},
+        {'region': '',
+         'namespace': '',
+         'metricName': '',
+         'statistics': [],
+         'dimensions': {},
+         'id': '',
+         'expression': '',
+         'period': '',
+         'alias': '',
+         'highResolution': False,
+         'refId': '',
+         'datasource': '',
+         'hide': False},
+        id='defaults',
+    ),
+    pytest.param(
+        {'region': 'us-east-1',
+         'namespace': 'AWS/RDS',
+         'metricName': 'CPUUtilization',
+         'statistics': ['Average'],
+         'dimensions': {'DBInstanceIdentifier': 'foo'},
+         'id': 'id',
+         'expression': 'expr',
+         'period': 'period',
+         'alias': 'alias',
+         'highResolution': True,
+         'refId': 'A',
+         'datasource': 'CloudWatch',
+         'hide': True,
+        },
+        {'region': 'us-east-1',
+         'namespace': 'AWS/RDS',
+         'metricName': 'CPUUtilization',
+         'statistics': ['Average'],
+         'dimensions': {'DBInstanceIdentifier': 'foo'},
+         'id': 'id',
+         'expression': 'expr',
+         'period': 'period',
+         'alias': 'alias',
+         'highResolution': True,
+         'refId': 'A',
+         'datasource': 'CloudWatch',
+         'hide': True,
+        },
+        id='custom',
+    )
+]
+
+@pytest.mark.parametrize("attrs,expected", CW_TESTDATA)
+def test_cloud_watch_target_json_data(attrs, expected):
+    assert G.CloudWatchTarget(**attrs).to_json_data() == expected


### PR DESCRIPTION
Opted for adding a `CloudWatchTarget` class rather than extending `Target` (or a new `BaseTarget` class) / removing attributes a-la https://github.com/weaveworks/grafanalib/pull/146.