### PR TITLE
INFRA-2905-add-decimals-field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,13 +2,21 @@
 Changelog
 =========
 
+0.5.8 (2019-04-09)
+==================
+
+Fixes
+-----
+
+* Add 'decimals' field to the Graph class to dictate significant digits in Grafana legend
+
+
 0.5.7 (2019-04-01)
 ==================
 
 Fixes
 -----
 * Add `Annotation` model for defining dashboard annotations
-
 
 0.5.6 (2019-02-21)
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1066,6 +1066,7 @@ class Graph(object):
     aliasColors = attr.ib(default=attr.Factory(dict))
     bars = attr.ib(default=False, validator=instance_of(bool))
     dataSource = attr.ib(default=None)
+    decimals = attr.ib(default=1)
     description = attr.ib(default=None)
     editable = attr.ib(default=True, validator=instance_of(bool))
     error = attr.ib(default=False, validator=instance_of(bool))
@@ -1112,6 +1113,7 @@ class Graph(object):
             'aliasColors': self.aliasColors,
             'bars': self.bars,
             'datasource': self.dataSource,
+            'decimals': self.decimals,
             'description': self.description,
             'editable': self.editable,
             'error': self.error,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.5.7',
+    version='0.5.8',
     description='Library for building Grafana dashboards',
     long_description=open(README).read(),
     url='https://github.com/weaveworks/grafanalib',


### PR DESCRIPTION
Add the `decimals` field to the Graph class so we can configure the number of significant digits in the legend during the mouseover.

I set the default value to 1 (eg, `30.0`) but happy to change that.

FYI @jmilliron 