### PR TITLE
Dw/make tests pass

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,5 @@ branch = True
 include =
     grafanalib/*.py
     grafanalib/**/*.py
+omit =
+    grafanalib/tests/*.py

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -538,7 +538,7 @@ def _balance_panels(panels):
 class Row(object):
     # TODO: jml would like to separate the balancing behaviour from this
     # layer.
-    panels = attr.ib(default=attr.Factory(list), convert=_balance_panels)
+    panels = attr.ib(default=attr.Factory(list), converter=_balance_panels)
     collapse = attr.ib(
         default=False, validator=instance_of(bool),
     )
@@ -550,7 +550,7 @@ class Row(object):
         validator=instance_of(Pixels),
     )
     showTitle = attr.ib(default=None)
-    title = attr.ib(default="")
+    title = attr.ib(default=None)
     repeat = attr.ib(default=None)
 
     def _iter_panels(self):
@@ -1103,7 +1103,7 @@ class Graph(object):
     # XXX: This isn't a *good* default, rather it's the default Grafana uses.
     yAxes = attr.ib(
         default=attr.Factory(YAxes),
-        convert=to_y_axes,
+        converter=to_y_axes,
         validator=instance_of(YAxes),
     )
     alert = attr.ib(default=None)

--- a/grafanalib/zabbix.py
+++ b/grafanalib/zabbix.py
@@ -821,7 +821,7 @@ class ZabbixTriggersPanel(object):
     transparent = attr.ib(default=False, validator=instance_of(bool))
     triggerSeverity = attr.ib(
         default=ZABBIX_SEVERITY_COLORS,
-        convert=convertZabbixSeverityColors,
+        converter=convertZabbixSeverityColors,
     )
     triggers = attr.ib(
         default=attr.Factory(ZabbixTrigger),

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.5.9',
+    version='0.6.0',
     description='Library for building Grafana dashboards',
     long_description=open(README).read(),
     url='https://github.com/weaveworks/grafanalib',
@@ -34,7 +34,7 @@ setup(
         'Topic :: System :: Monitoring',
     ],
     install_requires=[
-        'attrs',
+        'attrs>=19.3.0',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
This PR sets us up to make meaningful, test-backed, improvements to grafanalib.  As it is, even when run via `pytest` directly (ignoring Tox) the tests are just wrong!  When I did a `pip install -e .` per the instructions in the readme the version of `attrs` it installs makes the tests fail in 3 ways (fixed here) and there is a pure logic error in the remaining test - also corrected here.