### PR TITLE
more maxDataPoints default

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1910,7 +1910,8 @@ class Panel(object):
     id = attr.ib(default=None)
     interval = attr.ib(default=None)
     links = attr.ib(default=attr.Factory(list))
-    maxDataPoints = attr.ib(default=100)
+    # Use a larger maxDataPoints to get better graphs
+    maxDataPoints = attr.ib(default=1000)
     minSpan = attr.ib(default=None)
     repeat = attr.ib(default=attr.Factory(Repeat), validator=instance_of(Repeat))
     span = attr.ib(default=None)


### PR DESCRIPTION
The default maxDataPoints for panels is very low. We use panels everywhere in graphage. The default can be adjusted on a per panel template basis, but this is tiresome and people will forget when making new graphs. Let's just increase the value to a sensible default. Risk is this could perhaps increase load on prom, but I think that is a risk worth taking because without this change some of the graphs don't really have much utility at such a low resolution. 